### PR TITLE
Refactoring and async

### DIFF
--- a/smr/src/main/java/com/codeheadsystems/smr/Context.java
+++ b/smr/src/main/java/com/codeheadsystems/smr/Context.java
@@ -1,30 +1,28 @@
 package com.codeheadsystems.smr;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * You can have many contexts for a single state machine. And the
  * state machine manages this one context.
  */
-@FunctionalInterface
 public interface Context {
-
-  /**
-   * Reference atomic reference.
-   *
-   * @return the atomic reference
-   */
-  AtomicReference<State> reference();
 
   /**
    * State state.
    *
    * @return the state
    */
-  default State state() {
-    return reference().get();
-  }
+  State state();
 
+  /**
+   * Sets the current state to the new state, returning the existing state, if any.
+   *
+   * @param newState for the context.
+   * @return the old state
+   */
+  Optional<State> setState(State newState);
   /**
    * You can extend this to generate your own context easily enough.
    */
@@ -33,7 +31,7 @@ public interface Context {
     /**
      * The State.
      */
-    protected final AtomicReference<State> state;
+    private final AtomicReference<State> reference;
 
     /**
      * Instantiates a new .
@@ -41,12 +39,17 @@ public interface Context {
      * @param initialState the initial state
      */
     public Impl(State initialState) {
-      this.state = new AtomicReference<>(initialState);
+      this.reference = new AtomicReference<>(initialState);
     }
 
     @Override
-    public AtomicReference<State> reference() {
-      return state;
+    public State state() {
+      return reference.get();
+    }
+
+    @Override
+    public Optional<State> setState(State newState) {
+      return Optional.ofNullable(reference.getAndSet(newState));
     }
 
   }

--- a/smr/src/main/java/com/codeheadsystems/smr/Dispatcher.java
+++ b/smr/src/main/java/com/codeheadsystems/smr/Dispatcher.java
@@ -30,19 +30,6 @@ public interface Dispatcher {
                Consumer<Callback> contextConsumer);
 
   /**
-   * Wrapper to use the event unaware method in case you want to make decisions based on the
-   * event. This is not recommended as it breaks the state machine pattern, but you do you.
-   *
-   * @param context      that holds onto the current state.
-   * @param currentState expected current state.
-   * @param newState     new state to call.
-   * @param event        that caused the transition.
-   */
-  default void handleTransitionEvent(Context context, State currentState, State newState, Event event) {
-    handleTransitionEvent(context, currentState, newState);
-  }
-
-  /**
    * Macro method that handles the full state change and callback execution.
    *
    * @param context      that holds onto the current state.
@@ -50,6 +37,8 @@ public interface Dispatcher {
    * @param newState     new state to call.
    */
   void handleTransitionEvent(Context context, State currentState, State newState);
+
+  // ---- Below here exist for decorators ----
 
   /**
    * Does the state change.

--- a/smr/src/main/java/com/codeheadsystems/smr/StateMachine.java
+++ b/smr/src/main/java/com/codeheadsystems/smr/StateMachine.java
@@ -51,15 +51,6 @@ public class StateMachine extends Context.Impl {
   }
 
   /**
-   * The current state of the state machine.
-   *
-   * @return the current state.
-   */
-  public State state() {
-    return state.get();
-  }
-
-  /**
    * Get the states that are valid for the current state machine.
    *
    * @return set of states.
@@ -133,7 +124,7 @@ public class StateMachine extends Context.Impl {
     final Optional<State> optionalNewState = definition.forEvent(currentState, event);
     if (optionalNewState.isPresent()) {
       final State newState = optionalNewState.get();
-      dispatcher.handleTransitionEvent(this, currentState, newState, event);
+      dispatcher.handleTransitionEvent(this, currentState, newState);
       return newState;
     } else {
       log.warn("No transition for event {} from state {}", event, currentState);

--- a/smr/src/main/java/com/codeheadsystems/smr/dispatcher/AsynchronousDispatcher.java
+++ b/smr/src/main/java/com/codeheadsystems/smr/dispatcher/AsynchronousDispatcher.java
@@ -1,0 +1,75 @@
+package com.codeheadsystems.smr.dispatcher;
+
+import com.codeheadsystems.smr.Callback;
+import com.codeheadsystems.smr.State;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The type asynchronous dispatcher.
+ */
+public class AsynchronousDispatcher extends BaseDispatcher {
+
+  protected static final Logger log = LoggerFactory.getLogger(AsynchronousDispatcher.class);
+  private final Executor executor;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Instantiates a new Synchronous dispatcher.
+   *
+   * @param states   the states
+   * @param executor
+   */
+  private AsynchronousDispatcher(final Set<State> states, final Executor executor) {
+    super(states);
+    this.executor = executor;
+    log.info("SynchronousDispatcher()");
+  }
+
+  // A synchronized execution of the callbacks. Basic.
+  @Override
+  protected void executeCallbacks(final Set<Consumer<Callback>> phasedCallbacks,
+                                  final Callback callback) {
+    phasedCallbacks.stream()
+        .map(callbackConsumer ->
+            CompletableFuture.runAsync(() -> executeCallback(callbackConsumer, callback), executor))
+        .forEach(CompletableFuture::join);
+  }
+
+  public static class Builder {
+
+    private Executor executor;
+    private Set<State> states;
+
+    public Builder withExecutor(Executor executor) {
+      this.executor = executor;
+      return this;
+    }
+
+    public Builder withStates(Set<State> states) {
+      this.states = states;
+      return this;
+    }
+
+    public AsynchronousDispatcher build() {
+      if (states == null) {
+        throw new IllegalArgumentException("states must not be null");
+      }
+      Executor localExecutor = executor;
+      if (localExecutor == null) {
+        localExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+      }
+      return new AsynchronousDispatcher(states, localExecutor);
+    }
+
+  }
+
+}

--- a/smr/src/main/java/com/codeheadsystems/smr/dispatcher/BaseDispatcher.java
+++ b/smr/src/main/java/com/codeheadsystems/smr/dispatcher/BaseDispatcher.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class BaseDispatcher implements Dispatcher {
-  protected static final Logger log = LoggerFactory.getLogger(SynchronousDispatcher.class);
+  protected static final Logger log = LoggerFactory.getLogger(BaseDispatcher.class);
   protected final Map<State, Set<Consumer<Callback>>[]> callbackMap;
 
   public BaseDispatcher(final Set<State> states) {
@@ -64,7 +64,7 @@ public abstract class BaseDispatcher implements Dispatcher {
 
   @Override
   public State changeState(final Context context, final State currentState, final State newState) {
-    return context.reference().getAndSet(newState);
+    return context.setState(newState).orElse(null);
   }
 
   @Override

--- a/smr/src/main/java/com/codeheadsystems/smr/dispatcher/BaseDispatcher.java
+++ b/smr/src/main/java/com/codeheadsystems/smr/dispatcher/BaseDispatcher.java
@@ -1,0 +1,106 @@
+package com.codeheadsystems.smr.dispatcher;
+
+import com.codeheadsystems.smr.Callback;
+import com.codeheadsystems.smr.Context;
+import com.codeheadsystems.smr.Dispatcher;
+import com.codeheadsystems.smr.ImmutableCallback;
+import com.codeheadsystems.smr.Phase;
+import com.codeheadsystems.smr.State;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class BaseDispatcher implements Dispatcher {
+  protected static final Logger log = LoggerFactory.getLogger(SynchronousDispatcher.class);
+  protected final Map<State, Set<Consumer<Callback>>[]> callbackMap;
+
+  public BaseDispatcher(final Set<State> states) {
+    log.info("BaseDispatcher()");
+    this.callbackMap = states.stream()
+        .collect(HashMap::new, (map, state) -> map.put(state, buildList()), HashMap::putAll);
+  }
+
+  @Override
+  public void enable(final State state,
+                     final Phase phase,
+                     final Consumer<Callback> contextConsumer) {
+    log.trace("enable({}, {}, {})", state, phase, contextConsumer);
+    callbackMap.get(state)[phase.ordinal()].add(contextConsumer);
+  }
+
+  @Override
+  public void disable(final State state,
+                      final Phase phase,
+                      final Consumer<Callback> contextConsumer) {
+    log.trace("disable({}, {}, {})", state, phase, contextConsumer);
+    callbackMap.get(state)[phase.ordinal()].remove(contextConsumer);
+  }
+
+  /**
+   * TODO: This method needs to be handled with care. Need to consider if we want to 1) back out of events if
+   * things failed, 2) keep it simple but incomplete, 3) allow for various implementations. (Most likely).
+   *
+   * @param context      that has state being changed.
+   * @param currentState the from state.
+   * @param newState     the too state.
+   */
+  @Override
+  public void handleTransitionEvent(final Context context,
+                                    final State currentState,
+                                    final State newState) {
+    log.trace("handleTransitionEvent({}, {}, {})", context, currentState, newState);
+    dispatchCallbacks(context, currentState, Phase.EXIT);
+    final State previousState = changeState(context, currentState, newState);
+    if (!previousState.equals(currentState)) {
+      log.warn("handleTransitionEvent:state: {} != {}", previousState, currentState);
+    }
+    dispatchCallbacks(context, newState, Phase.ENTER);
+  }
+
+  @Override
+  public State changeState(final Context context, final State currentState, final State newState) {
+    return context.reference().getAndSet(newState);
+  }
+
+  @Override
+  public void dispatchCallbacks(final Context context,
+                                final State currentState,
+                                final Phase phase) {
+    log.trace("dispatchCallbacks({}, {}, {})", context, currentState, phase);
+    final Set<Consumer<Callback>>[] callbacks = callbackMap.get(currentState);
+    final Set<Consumer<Callback>> phasedCallbacks = callbacks[phase.ordinal()];
+    if (phasedCallbacks.isEmpty()) {
+      return;
+    }
+    final Callback callback = ImmutableCallback.builder()
+        .context(context)
+        .state(currentState)
+        .phase(phase)
+        .build();
+    executeCallbacks(phasedCallbacks, callback);
+  }
+
+  // Implement this for any logic you need.
+  abstract protected void executeCallbacks(Set<Consumer<Callback>> phasedCallbacks, final Callback callback);
+
+  @Override
+  public void executeCallback(final Consumer<Callback> consumer,
+                              final Callback callback) {
+    try {
+      consumer.accept(callback);
+    } catch (RuntimeException e) {
+      log.error("dispatchCallbacks:error: {}", consumer, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  protected Set<Consumer<Callback>>[] buildList() {
+    return Arrays.stream(Phase.values())
+        .map(event -> new HashSet<Consumer<Callback>>()).toArray(Set[]::new);
+  }
+}

--- a/smr/src/main/java/com/codeheadsystems/smr/dispatcher/SynchronousDispatcher.java
+++ b/smr/src/main/java/com/codeheadsystems/smr/dispatcher/SynchronousDispatcher.java
@@ -1,29 +1,15 @@
 package com.codeheadsystems.smr.dispatcher;
 
 import com.codeheadsystems.smr.Callback;
-import com.codeheadsystems.smr.Context;
-import com.codeheadsystems.smr.Dispatcher;
-import com.codeheadsystems.smr.ImmutableCallback;
 import com.codeheadsystems.smr.Phase;
 import com.codeheadsystems.smr.State;
-import com.codeheadsystems.smr.StateMachineDefinition;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The type Synchronous dispatcher.
  */
-public class SynchronousDispatcher implements Dispatcher {
-
-  private static final Logger log = LoggerFactory.getLogger(SynchronousDispatcher.class);
-
-  private final Map<State, Set<Consumer<Callback>>[]> callbackMap;
+public class SynchronousDispatcher extends BaseDispatcher {
 
   /**
    * Instantiates a new Synchronous dispatcher.
@@ -31,82 +17,17 @@ public class SynchronousDispatcher implements Dispatcher {
    * @param states the states
    */
   public SynchronousDispatcher(final Set<State> states) {
+    super(states);
     log.info("SynchronousDispatcher()");
-    this.callbackMap = states.stream()
-        .collect(HashMap::new, (map, state) -> map.put(state, buildList()), HashMap::putAll);
   }
 
+  // A synchronized execution of the callbacks. Basic.
   @Override
-  public void enable(final State state,
-                     final Phase phase,
-                     final Consumer<Callback> contextConsumer) {
-    log.trace("enable({}, {}, {})", state, phase, contextConsumer);
-    callbackMap.get(state)[phase.ordinal()].add(contextConsumer);
-  }
-
-  @Override
-  public void disable(final State state,
-                      final Phase phase,
-                      final Consumer<Callback> contextConsumer) {
-    log.trace("disable({}, {}, {})", state, phase, contextConsumer);
-    callbackMap.get(state)[phase.ordinal()].remove(contextConsumer);
-  }
-
-  /**
-   * TODO: This method needs to be handled with care. Need to consider if we want to 1) back out of events if
-   * things failed, 2) keep it simple but incomplete, 3) allow for various implementations. (Most likely).
-   *
-   * @param context      that has state being changed.
-   * @param currentState the from state.
-   * @param newState     the too state.
-   */
-  @Override
-  public void handleTransitionEvent(final Context context,
-                                    final State currentState,
-                                    final State newState) {
-    log.trace("handleTransitionEvent({}, {}, {})", context, currentState, newState);
-    dispatchCallbacks(context, currentState, Phase.EXIT);
-    final State previousState = changeState(context, currentState, newState);
-    if (!previousState.equals(currentState)) {
-      log.warn("handleTransitionEvent:state: {} != {}", previousState, currentState);
-    }
-    dispatchCallbacks(context, newState, Phase.ENTER);
-  }
-
-  @Override
-  public State changeState(final Context context, final State currentState, final State newState) {
-    return context.reference().getAndSet(newState);
-  }
-
-  @Override
-  public void dispatchCallbacks(final Context context,
-                                final State currentState,
-                                final Phase phase) {
-    log.trace("dispatchCallbacks({}, {}, {})", context, currentState, phase);
-    final Set<Consumer<Callback>>[] callbacks = callbackMap.get(currentState);
-    final Callback callback = ImmutableCallback.builder()
-        .context(context)
-        .state(currentState)
-        .phase(phase)
-        .build();
-    callbacks[phase.ordinal()].forEach(consumer -> {
+  protected void executeCallbacks(final Set<Consumer<Callback>> phasedCallbacks,
+                                  final Callback callback) {
+    phasedCallbacks.forEach(consumer -> {
       executeCallback(consumer, callback);
     });
-  }
-
-  @Override
-  public void executeCallback(final Consumer<Callback> consumer, final Callback callback) {
-    try {
-      consumer.accept(callback);
-    } catch (RuntimeException e) {
-      log.error("dispatchCallbacks:error: {}", consumer, e);
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private Set<Consumer<Callback>>[] buildList() {
-    return Arrays.stream(Phase.values())
-        .map(event -> new HashSet<Consumer<Callback>>()).toArray(Set[]::new);
   }
 
 }

--- a/smr/src/test/java/com/codeheadsystems/smr/TestBase.java
+++ b/smr/src/test/java/com/codeheadsystems/smr/TestBase.java
@@ -38,7 +38,7 @@ public class TestBase {
   /**
    * The State machine definition.
    */
-  protected StateMachineDefinition stateMachineDefinition = StateMachineDefinition.builder()
+  public static StateMachineDefinition stateMachineDefinition = StateMachineDefinition.builder()
       .addState(ONE).addState(TWO).addState(THREE)
       .setInitialState(ONE)
       .addTransition(ONE, TO_TWO, TWO)


### PR DESCRIPTION
1. Added more unit tests on the dispatcher
2. Created an async dispatcher
3. Updated the unit tests to test all (both) dispatchers the same
4. Modified context to be a domain object instead of just a wrapper for an atomic ref.