### PR TITLE
Run Dependabot weekly on Friday for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "friday"
     groups:
        # Specify a name for the group, which will be used in pull request titles
        # and branch names
@@ -19,3 +19,13 @@ updates:
           applies-to: version-updates # Applies the group rule to version updates
           patterns:
             - "*"       # Yolo!
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    groups:
+       github-actions:
+          applies-to: version-updates
+          patterns:
+            - "*"


### PR DESCRIPTION
## Summary
- Change the Gradle ecosystem schedule day from Monday to Friday.
- Add a `github-actions` package ecosystem, also scheduled weekly on Friday, so all components update on the same cadence.

## Notes
The new `github-actions` ecosystem keeps the workflow action versions in `.github/workflows` up to date, grouped into a single PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)